### PR TITLE
Fix dynamic PV provisioning check by adding a consumer pod

### DIFF
--- a/poc_prerequisite/armo-pv-check-pvc.yaml
+++ b/poc_prerequisite/armo-pv-check-pvc.yaml
@@ -8,3 +8,19 @@ spec:
   resources:
     requests:
       storage: 1Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: armo-pv-check-pod
+spec:
+  containers:
+  - name: test-container
+    image: busybox
+    volumeMounts:
+    - mountPath: "/usr/test"
+      name: pvc-storage
+  volumes:
+  - name: pvc-storage
+    persistentVolumeClaim:
+      claimName: armo-pv-check-pvc


### PR DESCRIPTION
Add a pod that consumes the PVC to properly test dynamic PV provisioning. This addresses cases where 'volumeBindingMode' is set to 'WaitForFirstConsumer', delaying volume binding until a pod uses the PVC.